### PR TITLE
Vs project inetfix

### DIFF
--- a/xbmc/win32/arpa/inet.h
+++ b/xbmc/win32/arpa/inet.h
@@ -20,4 +20,3 @@
 #pragma once
 #include <sys/socket.h>
 
-extern "C" int inet_pton(int af, const char *src, void *dst);


### PR DESCRIPTION
this fixes the inet_pton build error. 

Note: We can't get rid of the inet.h file overall, since it's used in cross-platform C++ code throughout our code base: `#include <arpa/inet.h>`
